### PR TITLE
Updating pipy-redis-sentinel sample to a new version.

### DIFF
--- a/pipy-redis-sentinel/docker-compose.yml
+++ b/pipy-redis-sentinel/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   pipy:
-    image: naqvis/pipy:0.30.0-23
+    image: flomesh/pipy:0.90.3-2
     container_name: pipy-proxy
     volumes:
       - ./pipy:/proxy:ro

--- a/pipy-redis-sentinel/pipy/config/config.json
+++ b/pipy-redis-sentinel/pipy/config/config.json
@@ -1,4 +1,5 @@
 {
+    "debug": true,
     "port" : 6379,
     "servers" : ["redis-master:6379", "redis-slave1:6379", "redis-slave2:6379"],
     "connectTimeout" : "1s",
@@ -7,6 +8,7 @@
     "healthcheck" : {
         "interval" : "5s",
         "connectTimeout" : "1s",
-        "readTimeout" : "1s"
+        "readTimeout" : "1s",
+        "maxTimeout": 3
     }
 }


### PR DESCRIPTION
Hi flomesh-io team

when I'm building redis HA cluster with pipy and sentinel, I found that the pipy image version of the sample in the demo was still 0.30.x, so I tried to read the latest documentation and update it with my own understanding of how this is used in the new version.

